### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/example/cmproject/global/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/cmproject/global/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.example.cmproject.global.config;
+
+import org.json.JSONObject;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setErrorResponse(response, accessDeniedException.getMessage());
+    }
+
+    public void setErrorResponse(HttpServletResponse response, String message) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("message", message);
+        response.getWriter().print(responseJson);
+    }
+}

--- a/src/main/java/com/example/cmproject/global/config/PageSizeConfig.java
+++ b/src/main/java/com/example/cmproject/global/config/PageSizeConfig.java
@@ -1,0 +1,7 @@
+package com.example.cmproject.global.config;
+
+public class PageSizeConfig {
+
+    public static final int User_List_Size = 20;
+    public static final int POST_LIST_SIZE = 20;
+}

--- a/src/main/java/com/example/cmproject/global/config/QuerydslConfiguration.java
+++ b/src/main/java/com/example/cmproject/global/config/QuerydslConfiguration.java
@@ -1,0 +1,20 @@
+package com.example.cmproject.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/cmproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cmproject/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_URLS = {
             "/auth/**", "/categories/**",
-            "/board", "/board/*",
+            "/comment/*", "/post/*",
             "/page/popular/regions", "/page/popular/products",
             "/page/**",
 

--- a/src/main/java/com/example/cmproject/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/cmproject/global/config/SwaggerConfig.java
@@ -1,0 +1,72 @@
+package com.example.cmproject.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.HttpAuthenticationScheme;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Arrays;
+import java.util.List;
+
+@EnableWebMvc
+@Configuration
+public class SwaggerConfig extends WebMvcConfigurationSupport {
+
+    private static final String REFERENCE = "Bearer";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30) // 3.0 문서버전으로 세팅
+                .groupName("게시판 커뮤니티 프로젝트")
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.example.cmproject"))
+//                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build()
+                .useDefaultResponseMessages(false)
+                .apiInfo(apiInfo())
+                .ignoredParameterTypes(AuthenticationPrincipal.class)
+                .securityContexts(List.of(securityContext()))
+                .securitySchemes(List.of(bearerAuthSecurityScheme()));
+
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("게시판 커뮤니티 프로젝트")
+                .description("게시판 커뮤니티 제작 ")
+//                .contact(new Contact("이름","홈페이지","email"))
+//                .license("라이센스소유자")
+//                .licenseUrl("라이센스URL")
+                .version("1.0")
+                .build();
+    }
+
+    private HttpAuthenticationScheme bearerAuthSecurityScheme() {
+        return HttpAuthenticationScheme.JWT_BEARER_BUILDER
+                .name(REFERENCE).build();
+    }
+
+    //JWT SecurityContext 구성
+    private SecurityContext securityContext() {
+        return SecurityContext.builder().securityReferences(defaultAuth()).build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEveryThing");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference(REFERENCE, authorizationScopes));
+    }
+}

--- a/src/main/java/com/example/cmproject/global/response/PageResponseDTO.java
+++ b/src/main/java/com/example/cmproject/global/response/PageResponseDTO.java
@@ -1,0 +1,25 @@
+package com.example.cmproject.global.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PageResponseDTO {
+    private List<?> content;
+    private int totalPages;
+    private long totalElements;
+    private int pageNumber;
+    private int size;
+
+    public PageResponseDTO(Page<?> page) {
+        this.content = page.getContent();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.pageNumber = page.getNumber() + 1;
+        this.size = page.getSize();
+    }
+}


### PR DESCRIPTION
[feat: PageResponseDTO](https://github.com/jini5/CMProject/commit/5010649db448f3e0512bd644dffbc7f6ed8646b1)
-  페이지네이션 결과를 담는 DTO 클래스

[feat: PageSizeConfig](https://github.com/jini5/CMProject/commit/b0e290be975ae1570e262e2973a7f7aed222bff1)

[feat: SwaggerConfig](https://github.com/jini5/CMProject/commit/f6c4d10fafea2c9695b3f954dd9f89d24ba882ef)
- Swagger 설정

[feat: QuerydslConfiguration](https://github.com/jini5/CMProject/commit/55d882b721a683c3e604a2c3fb1cd44a0a740535)
- Querydsl을 사용하여 데이터베이스에 쿼리를 날리기 위해 사용
- @PersistenceContext을 통해 엔티티 매니저를 주입받아 JPAQueryFactory 빈을 생성
- SQL 대신 자바 코드로 쿼리를 작성할 수 있다.

[feat: CustomAccessDeniedHandler](https://github.com/jini5/CMProject/commit/e7187dde1e23a1f7455a0cb7cbb8e09902a1493f)
- 권한이 없는 사용자가 접근한 경우 403 Forbidden 상태 코드와 함께 메시지를 출력


[feat: SecurityConfig](https://github.com/jini5/CMProject/pull/22/commits/6ce5082d7f2c07605ae0988c8696928866759d24)
- SecurityConfig 수정